### PR TITLE
Fix: GenerateKeysCommand could not be configured

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,7 +10,5 @@ services:
         public: true
 
     GeekCell\SodiumBundle\Command\GenerateKeysCommand:
-        arguments:
-            - '@GeekCell\SodiumBundle\Sodium\Sodium'
         tags:
             - { name: 'console.command' }


### PR DESCRIPTION
Currently the GenerateKeysCommand can not be automatically configured by symfony and prints out the error:
```                                                                                                                        
 [WARNING] Some commands could not be registered:                                                                       
                                                                                                                        

In Command.php line 114:
                                                                                                                                                                                                                                      
  Symfony\Component\Console\Command\Command::__construct(): Argument #1 ($name) must be of type ?string, GeekCell\SodiumBundle\Sodium\Sodium given, called in /tmp/dev/ContainerApo68V6/getGenerateKeysCommandService.php on line 20                                                                                                                                                                                                                        
```

This PR fixes this problem